### PR TITLE
fix: Disable checking HEAD first on provider download

### DIFF
--- a/internal/providercache/package_install.go
+++ b/internal/providercache/package_install.go
@@ -34,6 +34,7 @@ func installFromHTTPURL(ctx context.Context, meta getproviders.PackageMeta, targ
 		Client:                httpclient.New(),
 		Netrc:                 true,
 		XTerraformGetDisabled: true,
+		DoNotCheckHeadFirst:   true,
 	}
 
 	urlObj, err := url.Parse(urlStr)


### PR DESCRIPTION
Avoiding the new HEAD request that happens before GET request to get provider binary.

Fixes #36987

## Target Release

1.11.x

## Draft CHANGELOG entry

### BUG FIXES
- `terraform init` - avoid sending a HEAD request when fetching providers
